### PR TITLE
Remove ZENKIT_VERSION definition from .env

### DIFF
--- a/template/.env
+++ b/template/.env
@@ -1,2 +1,1 @@
-ZENKIT_VERSION=1.5.1
 SERVICE_IMAGE=zenoss/zing-{{Name}}

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,7 +1,7 @@
 {{ $pkg := print ((print (env "GOPATH") "/src/") | trimPrefix (env "PWD")) "/" Name -}}
-ARG ZENKIT_VERSION
+ARG ZENKIT_BUILD_VERSION=1.5.1
 
-FROM zenoss/zenkit-build:${ZENKIT_VERSION}
+FROM zenoss/zenkit-build:${ZENKIT_BUILD_VERSION}
 
 COPY . /go/src/{{$pkg}}
 WORKDIR /go/src/{{$pkg}}/{{Name}}

--- a/template/Makefile
+++ b/template/Makefile
@@ -11,7 +11,8 @@ DESIGNPKG            := $(PACKAGE)/design
 DESIGN 	             := $(shell find design -name \*.go)
 DOCKER_COMPOSE       := /usr/local/bin/docker-compose
 LOCAL_USER_ID        := $(shell id -u)
-BUILD_IMG            := zenoss/zenkit-build:$(ZENKIT_VERSION)
+ZENKIT_BUILD_VERSION := 1.5.1
+BUILD_IMG            := zenoss/zenkit-build:$(ZENKIT_BUILD_VERSION)
 COVERAGE_DIR         := coverage
 
 DOCKER_PARAMS        := --rm -v $(ROOTDIR):/go/src/$(PACKAGE):rw \

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -12,8 +12,6 @@ services:
           zenoss.zing.branch_name: ${GIT_BRANCH:-none}
           zenoss.zing.build_number: ${BUILD_ID:-none}
           zenoss.zing.build_url: ${BUILD_URL:-none}
-        args:
-          ZENKIT_VERSION: ${ZENKIT_VERSION}
     ports:
       - "{{Port}}"
     environment:


### PR DESCRIPTION
Move the definition of ZENKIT_VERSION from its shared location in the
.env file into the Makefile and Dockerfile.

This change was initially motivated by the need to override images for
development when running the full stack in zing-deploy.  In that usage,
a local override file is created in zing-deploy which sets the image's
build context to the project's directory.  However, this approach does
not include the project's .env, so the ZENKIT_VERSION was not defined.
Moving the definition from the .env to the Dockerfile resolves this
problem.

There was some concern about duplicating the definition in both the
Dockerfile and the Makefile; however after consideration it became
apparent that the two usages are distinct: the one in the Makefile is
used as an image for running various go-related tools; the one in the
Dockerfile is a base image for building the image.