### PR TITLE
Don't --strip-vendor on make vendor

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -56,7 +56,7 @@ glide.lock: glide.yaml
 
 vendor: glide.lock
 	@mkdir -p .glide
-	@$(GLIDE) install --force --strip-vendor
+	@$(GLIDE) install --force
 
 $(GOAGEN): vendor
 	@$(DOCKER_CMD) /bin/bash -c 'cd $(@D) && go build'


### PR DESCRIPTION
If you leave --strip-vendor in you will run into the sirupsen/Sirupsen case-insensitive import issue if you import libcompose, for example.