### PR TITLE
make it so service names with hyphens work

### DIFF
--- a/create-local.sh
+++ b/create-local.sh
@@ -6,6 +6,6 @@ docker run --rm \
 	-w /go/src/`dirname ${ROOTDIR#$GOPATH/src/}` \
 	-e LOCAL_USER_ID=$(id -u) \
 	-e IN_DOCKER=1 \
-	zenoss/zenkit-build:1.5.1 \
+	zenoss/zenkit-build:1.6.0 \
 	/usr/local/bin/create-zenkit-local.sh $1
 (cd $1; make)

--- a/create.sh
+++ b/create.sh
@@ -4,6 +4,6 @@ docker run --rm -it \
 	-w /go/src/${PWD#$GOPATH/src/} \
 	-e LOCAL_USER_ID=$(id -u) \
 	-e IN_DOCKER=1 \
-	zenoss/zenkit-build:1.5.1 \
+	zenoss/zenkit-build:1.6.0 \
 	/usr/local/bin/create-zenkit.sh $1
 (cd $1; make)

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,5 +1,5 @@
 {{ $pkg := print ((print (env "GOPATH") "/src/") | trimPrefix (env "PWD")) "/" Name -}}
-ARG ZENKIT_BUILD_VERSION=1.5.1
+ARG ZENKIT_BUILD_VERSION=1.6.0
 
 FROM zenoss/zenkit-build:${ZENKIT_BUILD_VERSION}
 

--- a/template/Makefile
+++ b/template/Makefile
@@ -11,7 +11,7 @@ DESIGNPKG            := $(PACKAGE)/design
 DESIGN 	             := $(shell find design -name \*.go)
 DOCKER_COMPOSE       := /usr/local/bin/docker-compose
 LOCAL_USER_ID        := $(shell id -u)
-ZENKIT_BUILD_VERSION := 1.5.1
+ZENKIT_BUILD_VERSION := 1.6.0
 BUILD_IMG            := zenoss/zenkit-build:$(ZENKIT_BUILD_VERSION)
 COVERAGE_DIR         := coverage
 

--- a/template/Makefile
+++ b/template/Makefile
@@ -11,7 +11,7 @@ DESIGNPKG            := $(PACKAGE)/design
 DESIGN 	             := $(shell find design -name \*.go)
 DOCKER_COMPOSE       := /usr/local/bin/docker-compose
 LOCAL_USER_ID        := $(shell id -u)
-ZENKIT_BUILD_VERSION := 1.6.0
+ZENKIT_BUILD_VERSION := 1.5.1
 BUILD_IMG            := zenoss/zenkit-build:$(ZENKIT_BUILD_VERSION)
 COVERAGE_DIR         := coverage
 

--- a/template/README.md
+++ b/template/README.md
@@ -13,8 +13,8 @@ need to go into as much specificity as the Swagger spec will, but be
 descriptive.
 
 ## Configuration
-* `{{Name | toUpper}}_LOG_LEVEL`: Log level. Defaults to "info".
-* `{{Name | toUpper}}_HTTP_PORT`: Port on which the HTTP API service listens. Defaults to {{Port}}.
-* `{{Name | toUpper}}_AUTH_DISABLED`: Whether authentication is enforced. If true, middleware is used that injects an admin identity into unauthenticated requests.
-* `{{Name | toUpper}}_AUTH_KEY_FILE`: The file containing the secret key that is used to validate incoming authentication tokens.
-* `{{Name | toUpper}}_TRACING_ENABLED`: Whether request tracing is enabled.
+* `{{replace Name "-" "_" -1 | toUpper}}_LOG_LEVEL`: Log level. Defaults to "info".
+* `{{replace Name "-" "_" -1 | toUpper}}_HTTP_PORT`: Port on which the HTTP API service listens. Defaults to {{Port}}.
+* `{{replace Name "-" "_" -1 | toUpper}}_AUTH_DISABLED`: Whether authentication is enforced. If true, middleware is used that injects an admin identity into unauthenticated requests.
+* `{{replace Name "-" "_" -1 | toUpper}}_AUTH_KEY_FILE`: The file containing the secret key that is used to validate incoming authentication tokens.
+* `{{replace Name "-" "_" -1 | toUpper}}_TRACING_ENABLED`: Whether request tracing is enabled.

--- a/template/design/api.go
+++ b/template/design/api.go
@@ -5,7 +5,7 @@ import (
 	"github.com/zenoss/zenkit"
 )
 
-var _ = API("{{Name}}", func() {
+var _ = API("{{camel Name "-" | title}}", func() {
 	Title("{{Title}}")
 	Description("{{Description}}")
 	Scheme("http")

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -15,11 +15,11 @@ services:
     ports:
       - "{{Port}}"
     environment:
-      {{Name | toUpper}}_LOG_LEVEL: info
-      {{Name | toUpper}}_HTTP_PORT: {{Port}}
-      {{Name | toUpper}}_AUTH_DISABLED: 1
-      {{Name | toUpper}}_AUTH_KEY_FILE: /run/secrets/auth_key
-      {{Name | toUpper}}_TRACING_ENABLED: 0
+      {{replace Name "-" "_" -1 | toUpper}}_LOG_LEVEL: info
+      {{replace Name "-" "_" -1 | toUpper}}_HTTP_PORT: {{Port}}
+      {{replace Name "-" "_" -1 | toUpper}}_AUTH_DISABLED: 1
+      {{replace Name "-" "_" -1 | toUpper}}_AUTH_KEY_FILE: /run/secrets/auth_key
+      {{replace Name "-" "_" -1 | toUpper}}_TRACING_ENABLED: 0
     secrets:
       - auth_key
 secrets:

--- a/template/glide.yaml
+++ b/template/glide.yaml
@@ -41,7 +41,7 @@ import:
 - package: github.com/cenkalti/backoff
   version: 1.0.0
 - package: github.com/snikch/goodman
-  version: 0.2.3
+  version: 0.3.1
 - package: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - package: github.com/fsnotify/fsnotify

--- a/template/hooks/{{Name}}_hooks.go
+++ b/template/hooks/{{Name}}_hooks.go
@@ -27,7 +27,7 @@ func main() {
 		a, _ := strconv.Atoi(parts[2])
 		b, _ := strconv.Atoi(parts[3])
 
-		actual := &app.X{{Name | title}}Sum{}
+		actual := &app.X{{camel Name "-" | title}}Sum{}
 		_ = json.Unmarshal([]byte(t.Real.Body), actual)
 
 		if total := a + b; total != actual.Total {

--- a/template/hooks/{{Name}}_hooks.go
+++ b/template/hooks/{{Name}}_hooks.go
@@ -21,6 +21,16 @@ func main() {
 		t.Skip = strings.HasPrefix(t.Name, "admin >")
 	})
 
+	// skip the 400 result from the example
+	h.Before("example > /hello/{name} > greet example > 400 > application/x.{{Name}}.greeting+json", func(t *trans.Transaction) {
+		t.Skip = true
+	})
+
+	// skip the websocket example
+	h.Before("example > /words > words example > 101 > application/json", func(t *trans.Transaction) {
+		t.Skip = true
+	})
+
 	// a detailed example
 	h.After("example > /add/{a}/{b} > add example > 200 > application/x.tester.sum+json", func(t *trans.Transaction) {
 		parts := strings.Split(t.FullPath, "/")

--- a/template/resources/admin.go
+++ b/template/resources/admin.go
@@ -53,7 +53,7 @@ func (c *AdminController) Swagger(ctx *app.SwaggerAdminContext) error {
 	return ctx.OK([]byte(`<!DOCTYPE html
 <html>
   <head>
-    <title>{{Name | title}} API</title>
+    <title>{{replace Name "-" " " -1 | title}} API</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       body {

--- a/template/resources/example.go
+++ b/template/resources/example.go
@@ -33,13 +33,13 @@ func (c *ExampleController) Add(ctx *app.AddExampleContext) error {
 	total := ctx.A + ctx.B
 
 	// Keep a running total for no reason
-	ctr := metrics.GetOrRegisterCounter("{{Name}}.Add.total", zenkit.ContextMetrics(ctx))
+	ctr := metrics.GetOrRegisterCounter("{{camel Name "-" | title}}.Add.total", zenkit.ContextMetrics(ctx))
 	ctr.Inc(int64(total))
 
-	return ctx.OK(&app.X{{Name | title}}Sum{Total: total})
+	return ctx.OK(&app.X{{camel Name "-" | title}}Sum{Total: total})
 
 	// ExampleController_Add: end_implement
-	res := &app.X{{Name | title}}Sum{}
+	res := &app.X{{camel Name "-" | title}}Sum{}
 	return ctx.OK(res)
 }
 
@@ -53,10 +53,10 @@ func (c *ExampleController) Greet(ctx *app.GreetExampleContext) error {
 		return ctx.BadRequest()
 	}
 	result := fmt.Sprintf("Hello, %s!", ctx.Name)
-	return ctx.OK(&app.X{{Name | title}}Greeting{Greeting: result})
+	return ctx.OK(&app.X{{camel Name "-" | title}}Greeting{Greeting: result})
 
 	// ExampleController_Greet: end_implement
-	res := &app.X{{Name | title}}Greeting{}
+	res := &app.X{{camel Name "-" | title}}Greeting{}
 	return ctx.OK(res)
 }
 

--- a/template/resources/resources_suite_test.go
+++ b/template/resources/resources_suite_test.go
@@ -14,5 +14,5 @@ func TestResources(t *testing.T) {
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("junit.xml")
 	rand.Seed(GinkgoRandomSeed())
-	RunSpecsWithDefaultAndCustomReporters(t, "{{Name | title}} Resources Suite", []Reporter{junitReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "{{camel Name "-" | title}} Resources Suite", []Reporter{junitReporter})
 }


### PR DESCRIPTION
I updated the build job so that it creates a service with hyphens in the name.

* Note that the makefile is still using 1.5.1 of zenkit-build while the Dockerfile is on 1.6.0.  There seems to be a bug in the api hooks dependency.