### PR TITLE
Don't trigger acceptance tests on PR build

### DIFF
--- a/template/ci/Jenkinsfile
+++ b/template/ci/Jenkinsfile
@@ -63,53 +63,5 @@ node('docker') {
                 sh("${MAKE} down")
             }
         }
-
-        try {
-            configFileProvider([configFile(fileId: 'disable-release', variable: 'DISABLE_RELEASE')]) {
-                echo 'Production releases are DISABLED.  To enable, delete the "disable-release" config file from the service\'s folder'
-            }
-        } catch (Exception e) {
-            stage('Publish image') {
-                def pubSteps = [:]
-                for (int i = 0; i < global.PUBLISHERS.size(); i++) {
-                    def registry = "${global.PUBLISHERS[i]}"
-                    def stepName  = "publishing image to [${i}] ${registry}"
-                    pubSteps[stepName] = {
-                        sh("${MAKE} push REGISTRY=${registry}")
-                    }
-                }
-                parallel pubSteps
-            }
-
-            stage('Acceptance tests') {
-                sh("${MAKE} ci/version.yml")
-                archiveArtifacts artifacts: 'ci/version.yml'
-
-                staging = build job: env.GLOBAL_ACCEPTANCE_JOB, propagate: false, parameters: [
-                    text(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
-                    text(name: 'OVERRIDE_BUILD_ID', value:"{{Name}} PR#${ghprbPullId}"),
-                ]
-                step([
-                    $class: 'CopyArtifact',
-                    filter: 'test/e2e/reports/cucumber.html',
-                    fingerprintArtifacts: true,
-                    flatten: true,
-                    optional: true,
-                    projectName: staging.buildVariables.AcceptanceTestJobName,
-                    selector: [$class: 'SpecificBuildSelector', buildNumber: staging.buildVariables.AcceptanceTestBuildNumber],
-                    target: 'reports',
-                ])
-                publishHTML([
-                    allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'reports',
-                    reportFiles: 'cucumber.html',
-                    reportName: 'Acceptance Test Report',
-                    reportTitles: ''
-                ])
-                currentBuild.result = staging.getResult()
-            }
-        }
     }
 }


### PR DESCRIPTION
In the new approach for GCP, we plan on running acceptance tests in a test environment that the services are deployed to BEFORE promoting images to a staging environment. The deploy to the test environment will be triggered whenever code is merged master, so we don't need to run acceptance tests on PR builds.