### PR TITLE
Make ci/version.env instead of ci/version.yml

### DIFF
--- a/template/ci/.gitignore
+++ b/template/ci/.gitignore
@@ -1,2 +1,2 @@
 docker-compose.yml
-version.yml
+version.env

--- a/template/ci/Makefile
+++ b/template/ci/Makefile
@@ -13,6 +13,7 @@ else
 REMOTE_IMAGE := ${REGISTRY}/${SERVICE_IMAGE}:$(if ${REMOTE_TAG},${REMOTE_TAG},${IMAGE_TAG})
 endif
 
+# FIXME: This can be probably be removed once zenkit no longer uses the auth_key.secrets
 define CI_DOCKER_COMPOSE_YAML
 version: "3.3"
 secrets:
@@ -23,6 +24,7 @@ endef
 ci/docker-compose.yml: export CI_DOCKER_COMPOSE_YAML:=$(CI_DOCKER_COMPOSE_YAML)
 ci/docker-compose.yml:
 	@echo "$$CI_DOCKER_COMPOSE_YAML" > $@
+
 
 .PHONY: IMAGE_NAME_VALID
 IMAGE_NAME_VALID:
@@ -52,18 +54,15 @@ GCR_CREDS_VALID:
 	@test ${GCR_KEY_FILE} || (echo "GCR_KEY_FILE must be defined"; false)
 	@test ${ZING_REPOSITORY} || (echo "ZING_REPOSITORY must be defined"; false)
 
-define VERSION_YAML
-version: "3.2"
-services:
-    $${SERVICE_NAME}:
-        image: $${ZING_REGISTRY}/$${ZING_REPOSITORY}/$(SERVICE_NAME):${IMAGE_TAG}
+define VERSION_ENV
+IMAGE_TAG=${IMAGE_TAG}
 endef
 
-ci/version.yml: export VERSION_YAML:=$(VERSION_YAML)
-ci/version.yml: IMAGE_NAME_VALID
-	@echo "$$VERSION_YAML" > $@
+ci/version.env: export VERSION_ENV:=$(VERSION_ENV)
+ci/version.env: IMAGE_NAME_VALID
+	@echo "$$VERSION_ENV" > $@
 
 .PHONY: clean
 clean::
-	rm -f ci/version.yml
+	rm -f ci/version.env
 	rm -f ci/docker-compose.yml

--- a/template/glide.yaml
+++ b/template/glide.yaml
@@ -19,7 +19,7 @@ import:
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - websocket
-- name: github.com/satori/go.uuid
+- package: github.com/satori/go.uuid
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - package: github.com/zenoss/zenkit
   version: 2.1.0

--- a/template/glide.yaml
+++ b/template/glide.yaml
@@ -19,6 +19,8 @@ import:
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - websocket
+- name: github.com/satori/go.uuid
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - package: github.com/zenoss/zenkit
   version: 2.1.0
 - package: gopkg.in/yaml.v2


### PR DESCRIPTION
Companion to https://github.com/zenoss/zing-ci/pull/13

Follow-up work:
* Copy these files to reporter, graphql, zing-traefik and zing-web repos
* Simplify zing-deploy