### PR TITLE
Catch and log RunGRPCServer errors

### DIFF
--- a/template/main.go
+++ b/template/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"google.golang.org/grpc/grpclog"
 
 	"github.com/zenoss/zenkit"
 	// proto "github.com/zenoss/zing-proto/go/{{Name}}"
@@ -13,7 +14,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	zenkit.RunGRPCServer(ctx, "{{Name}}", func(svr *grpc.Server) error {
+	err := zenkit.RunGRPCServer(ctx, "{{Name}}", func(svr *grpc.Server) error {
 
 		// Fill this in with your service details
 
@@ -22,5 +23,7 @@ func main() {
 		return nil
 
 	})
-
+	if err != nil {
+		grpclog.Errorf("Error running GRPC server: %s", err.Error())
+	}
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-2694

Catch and log errors thrown in RunGRPCServer errors. If the main service panics we need to see these errors in the service logs so we can diagnose what's wrong (we saw this, ie, when an environment variable was missing and the config raised an exception)