### PR TITLE
ZING-10493: add manifests to zenkit-template

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,5 +1,6 @@
 # The binary itself
 shortlink
+{{Name}}
 
 # Binaries for programs and plugins
 *.exe

--- a/template/go.mod
+++ b/template/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/zenoss/zenkit/v5 v5.0.4
+	github.com/zenoss/zenkit/v5 v5.0.9
 	google.golang.org/grpc v1.29.1
 )

--- a/template/main.go
+++ b/template/main.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/zenoss/zenkit/v5"
-	// proto "github.com/zenoss/zing-proto/v11/go/{{Name}}"
+	// proto "github.com/zenoss/zing-proto/v11/go/cloud/{{Name}}"
 )
 
 const (

--- a/template/manifests/base/autoscaler.yaml
+++ b/template/manifests/base/autoscaler.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{Name}}
+spec:
+  minReplicas: 1
+  maxReplicas: 16
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: 80
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{Name}}

--- a/template/manifests/base/deployment.yaml
+++ b/template/manifests/base/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{Name}}
+  name: {{Name}}
+spec:
+  selector:
+    matchLabels:
+      app: {{Name}}
+  template:
+    metadata:
+      labels:
+        app: {{Name}}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - {{Name}}
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: {{Name}}
+        image: {{Name}}
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 512
+        ports:
+          - containerPort: 8081
+        env:
+          - name: ZING_PRODUCT_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: project-common
+                key: PRODUCT_NAME
+          - name: ZING_PRODUCT_VERSION
+            valueFrom:
+              configMapKeyRef:
+                name: project-common
+                key: PRODUCT_VERSION
+          - name: ZING_PRODUCT_COMPANY_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: project-common
+                key: COMPANY_NAME
+          - name: ZING_PRODUCT_OTHER_COMMENTS
+            valueFrom:
+              configMapKeyRef:
+                name: project-common
+                key: PROJECT_ID
+          - name: LISTEN_ADDR
+            value: "0.0.0.0:8080"
+          - name: {{replace Name "-" "_" -1 | toUpper}}_GCLOUD_PROJECT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: project-common
+                key: PROJECT_ID
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: "/run/credentials/{{Name}}.json"
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1000M
+          limits:
+            cpu: 1500m
+            memory: 1000M
+        volumeMounts:
+          - name: cred-secrets
+            mountPath: /run/credentials
+            readOnly: true
+      volumes:
+        - name: cred-secrets
+          secret:
+            secretName: {{Name}}

--- a/template/manifests/base/kustomization.yaml
+++ b/template/manifests/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- autoscaler.yaml
+- service.yaml
+- pdb.yaml

--- a/template/manifests/base/pdb.yaml
+++ b/template/manifests/base/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{Name}}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: {{Name}}

--- a/template/manifests/base/service.yaml
+++ b/template/manifests/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{Name}}
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+  selector:
+    app: {{Name}}
+  type: ClusterIP

--- a/template/manifests/base/service.yaml
+++ b/template/manifests/base/service.yaml
@@ -11,3 +11,4 @@ spec:
   selector:
     app: {{Name}}
   type: ClusterIP
+  

--- a/template/manifests/zcloud-emea/custom-env.yaml
+++ b/template/manifests/zcloud-emea/custom-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{Name}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{Name}}
+        env:
+          - name: {{replace Name "-" "_" -1 | toUpper}}_LOG_LEVEL
+            value: "error"

--- a/template/manifests/zcloud-emea/kustomization.yaml
+++ b/template/manifests/zcloud-emea/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- pdb.yaml
+- set-replicas.yaml
+- custom-env.yaml

--- a/template/manifests/zcloud-emea/pdb.yaml
+++ b/template/manifests/zcloud-emea/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{Name}}
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: {{Name}}

--- a/template/manifests/zcloud-emea/set-replicas.yaml
+++ b/template/manifests/zcloud-emea/set-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{Name}}
+spec:
+  minReplicas: 2

--- a/template/manifests/zcloud-prod/custom-env.yaml
+++ b/template/manifests/zcloud-prod/custom-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{Name}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{Name}}
+        env:
+          - name: {{replace Name "-" "_" -1 | toUpper}}_LOG_LEVEL
+            value: "error"

--- a/template/manifests/zcloud-prod/kustomization.yaml
+++ b/template/manifests/zcloud-prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- pdb.yaml
+- set-replicas.yaml
+- custom-env.yaml

--- a/template/manifests/zcloud-prod/pdb.yaml
+++ b/template/manifests/zcloud-prod/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{Name}}
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: {{Name}}

--- a/template/manifests/zcloud-prod/set-replicas.yaml
+++ b/template/manifests/zcloud-prod/set-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{Name}}
+spec:
+  minReplicas: 3

--- a/template/manifests/zcloud-prod/set-replicas.yaml
+++ b/template/manifests/zcloud-prod/set-replicas.yaml
@@ -4,3 +4,4 @@ metadata:
   name: {{Name}}
 spec:
   minReplicas: 3
+  

--- a/template/manifests/zing-dev/kustomization.yaml
+++ b/template/manifests/zing-dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- set-resources.yaml

--- a/template/manifests/zing-dev/set-resources.yaml
+++ b/template/manifests/zing-dev/set-resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{Name}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{Name}}
+        resources:
+          requests:
+            memory: 512M
+            cpu: 800m
+          limits:
+            memory: 1000M
+            cpu: 1500m

--- a/template/manifests/zing-perf/kustomization.yaml
+++ b/template/manifests/zing-perf/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/template/manifests/zing-preview/custom-env.yaml
+++ b/template/manifests/zing-preview/custom-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{Name}}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{Name}}
+        env:
+          - name: {{replace Name "-" "_" -1 | toUpper}}_LOG_LEVEL
+            value: "error"

--- a/template/manifests/zing-preview/kustomization.yaml
+++ b/template/manifests/zing-preview/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- custom-env.yaml

--- a/template/manifests/zing-testing/kustomization.yaml
+++ b/template/manifests/zing-testing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
- add manifests for k8s deployment
- bump zenkit microversion
- add service binary to .gitignore
- update default zing-proto pkg URL to be child of ../cloud