### PR TITLE
ZING-32416: add envFrom project-env ConfigMap 

### DIFF
--- a/template/manifests/base/deployment.yaml
+++ b/template/manifests/base/deployment.yaml
@@ -36,6 +36,9 @@ spec:
                 key: PROJECT_ID
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: "/run/credentials/{{Name}}.json"
+        envFrom:
+          - configMapRef:
+              name: project-env
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
All service containers will need this to support sending metrics to
zing-otel-collector.
