### PR TITLE
ZING-37131: default HPA to only scale on CPU

### DIFF
--- a/template/manifests/base/hpa.yaml
+++ b/template/manifests/base/hpa.yaml
@@ -9,12 +9,13 @@ spec:
   minReplicas: 2
   maxReplicas: 16
   metrics:
-  - type: Resource
-    resource:
+  - type: ContainerResource
+    containerResource:
+      container: {{Name}}
       name: cpu
       target:
-        type: Utilization
-        averageUtilization: 300
+        type: AverageValue
+        averageValue: 300
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
Switching from `Resource` to `ContainerResource` because we don't want
other containers like sidecars factored into the scaling decision.
