### PR TITLE
ZING-41411: use ginkgo version defined in go.mod

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -20,7 +20,6 @@ SHELL                := $(shell command -v bash 2> /dev/null)
 GO                   := $(shell command -v go 2> /dev/null)
 GOLANGCI_LINT        := $(shell command -v golangci-lint 2> /dev/null)
 GOVULNCHECK          := $(shell command -v govulncheck 2> /dev/null)
-GINKGO               := $(shell command -v ginkgo 2> /dev/null)
 GOCOV                := $(shell command -v gocov 2> /dev/null)
 GOCOVXML             := $(shell command -v gocov-xml 2> /dev/null)
 MOCKERY              := $(shell command -v mockery 2> /dev/null)
@@ -90,12 +89,9 @@ unit-test: COVERAGE_PROFILE := coverprofile.out
 unit-test: COVERAGE_HTML    := $(COVERAGE_DIR)/index.html
 unit-test: COVERAGE_XML     := $(COVERAGE_DIR)/coverage.xml
 unit-test:
-ifeq ($(strip $(GINKGO)),)
-	@echo "$(RED) Warning: ginkgo is not available on this system, please install it"
-else
 	@echo "$(M) ginkgo: running tests…"
 	@mkdir -p $(COVERAGE_DIR)
-	@$(GINKGO) \
+	@$(GO) run github.com/onsi/ginkgo/v2/ginkgo \
 		run \
 		-r \
 		--mod vendor \
@@ -107,7 +103,6 @@ else
 		--junit-report junit.xml
 	@$(GO) tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)
 	@$(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
-endif
 
 .PHONY: mocks
 mocks:

--- a/template/Makefile
+++ b/template/Makefile
@@ -91,7 +91,7 @@ unit-test: COVERAGE_XML     := $(COVERAGE_DIR)/coverage.xml
 unit-test:
 	@echo "$(M) ginkgo: running tests…"
 	@mkdir -p $(COVERAGE_DIR)
-	@$(GO) run github.com/onsi/ginkgo/v2/ginkgo \
+	@$(GO) tool ginkgo \
 		run \
 		-r \
 		--mod vendor \

--- a/template/go.mod
+++ b/template/go.mod
@@ -1,3 +1,5 @@
 module github.com/zenoss/{{Name}}
 
 go 1.25
+
+tool github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
The purpose of this is to avoid warnings like the following when running
tests natively (not in the zenkit-build image), or when the project's
ginkgo version doesn't match the version in the zenkit-build image being
used.

It also means developers who want to run tests outside of a container
don't need to have a local version of ginkgo installed at all.

```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.27.2
  Mismatched package versions found:
    2.27.3 used by config, delay, dispatch, anyutils, clauseutils, matches, zenoss, secrets, credsvc, itemcontext, multiitem, anomalyprocessor, delayprocessor, eventprocessor, maintwindowprocessor, metricprocessor, percentdur, simpleminmax, trigmap, redis, processorutils, staleprocessor, pubsubmanager, email, webhook, event, globalview, api, topology, template, msteams, pagerduty, servicenow, v2, slack, webhook, senderbuilder, service, secretreplace, stale, store, integration, util, yamrtool

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
```
